### PR TITLE
Allow spaces in the application name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# dependencies
 node_modules
+
+# logs
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -48,6 +48,11 @@ const adjustRenderer = directory => {
       path = join(directory, 'out', path)
     }
 
+    // Electron doesn't like anything in the path to be encoded,
+    // so we need to undo that. This specifically allows for
+    // Electron apps with spaces in their app names.
+    path = decodeURIComponent(path)
+
     callback({ path })
   })
 }


### PR DESCRIPTION
### Description

Electron apps with spaces in their names were loading with a blank white screen, while throwing console errors saying that it could't find the files within the packaged app.

An example error message that was being thrown.

```
Not allowed to load local resource: file:///Users/manovotny/Developer/electron-next-skeleton/dist/mac/Electron%20Next.app/Contents/Resources/app.asar/renderer/out/start/index.html
```

Specifically notice the `%20` in the app name. This made Electron very unhappy.

The fix was to decode the path name, which made Electron happy again and the app files were able to load properly.

### Steps to Reproduce Error

1. Clone [electron-next-skeleton](https://github.com/leo/electron-next-skeleton)
1. Change `productName` in `package.json` from `ElectronNext` to `Electron Next`
1. Run `npm run dist`
1. Double click `dist/mac/Electron Next.app` to open the app
1. Notice it loads a blank white page and there is an error in the console (might need to install [electron-debug](https://github.com/sindresorhus/electron-debug) to see console error)

I also narrowed down the problem to `electron-next` by verify that [electron-packager](https://github.com/electron-userland/electron-packager) and [electron-builder](https://github.com/electron-userland/electron-builder) can handle spaces in app names by using the following steps.

1. Download the minimalistic [electron-quick-start](https://github.com/electron/electron-quick-start) project, initialize it, and test that it works.

```
git clone git@github.com:electron/electron-quick-start.git
cd electron-quick-start
npm i
npm start
```

2. Install `electron-packager` and / or `electron-builder` which wraps ASAR.

```
npm i electron-packager
```

3. Add a `productName`, with spaces, to `package.json`.

```
"productName": "Electron Quick Start"
```

4. Add `dist` script by adding the following to `scripts` in `package.json`.

```
"dist": "electron-packager . --out dist"
```

5. Run the `dist` script.

```
npm run dist
```

6. Double click the `Electron Quick Start.app` app in the generated `dist` directory and notice that the app loads / runs without errors.

### Testing 

I have tested this locally by using `npm link` with [electron-next-skeleton](https://github.com/leo/electron-next-skeleton) and with the [`with-electron` example in `next.js`](https://github.com/zeit/next.js/tree/master/examples/with-electron), though I wound't mind some additional verification by a second set of eyes. 👀 